### PR TITLE
docs: add contributing badge and fix header / build-status image links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img height="170x" src="https://media.discordapp.net/attachments/813444514949103658/890278520553603092/export.png?width=746&height=746" />
+  <img height="170x" src="https://camo.githubusercontent.com/590ccfb4e70a27673047ee879ed409981c05b2da403e60b4aaa7961ccdb46001/68747470733a2f2f7062732e7477696d672e636f6d2f6d656469612f46565556614f3958454141756c764b3f666f726d61743d706e67266e616d653d736d616c6c?width=746&height=746" />
 
   <h1>Anchor</h1>
 
@@ -8,10 +8,11 @@
   </p>
 
   <p>
-    <a href="https://travis-ci.com/project-serum/anchor"><img alt="Build Status" src="https://travis-ci.com/project-serum/anchor.svg?branch=master&color=blueviolet" /></a>
+    <a href="https://github.com/coral-xyz/anchor/actions"><img alt="Build Status" src="https://github.com/coral-xyz/anchor/actions/workflows/tests.yaml/badge.svg?color=blueviolet" /></a>
     <a href="https://project-serum.github.io/anchor/"><img alt="Tutorials" src="https://img.shields.io/badge/docs-tutorials-blueviolet" /></a>
     <a href="https://discord.com/channels/889577356681945098"><img alt="Discord Chat" src="https://img.shields.io/discord/889577356681945098?color=blueviolet" /></a>
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License" src="https://img.shields.io/github/license/project-serum/anchor?color=blueviolet" /></a>
+    <a href="https://github.com/UXDProtocol/anchor/blob/master/CONTRIBUTING.md"><img alt="Contributing" src="https://img.shields.io/badge/Contributing-welcome-brightgreen.svg?color=blueviolet" /></a>
   </p>
 </div>
 


### PR DESCRIPTION
Added a contributing badge and fixed several README image links to improve presentation and contributor onboarding.

- Added a "Contributing" badge linking to the CONTRIBUTING.md file:
  https://github.com/UXDProtocol/anchor/blob/master/CONTRIBUTING.md

- Replaced the previous (broken or outdated) build status badge with the GitHub Actions workflow badge:
  https://github.com/coral-xyz/anchor/actions/workflows/tests.yaml/badge.svg

- Updated the header image source to a working camo.githubusercontent.com URL to avoid a 404.

Files changed:
- README.md

## Current behavior
- The README referenced a build-status image and header image that resulted in broken/404 renders.
- There was no prominent contributing badge linking to the repository CONTRIBUTING.md.

## New behavior
- README now shows a working build-status badge sourced from the repository's GitHub Actions.
- README header image URL has been updated to a valid URL to ensure proper rendering.
- A contributing badge has been added and links directly to the CONTRIBUTING.md file to help new contributors find guidelines quickly.

## Breaking changes
None — documentation-only update.

## Other information / notes for maintainers
- All changes only affect README assets and links.
- If maintainers prefer different badge styles, hosts, or wish to use locally committed images instead of remote URLs, I can adapt the PR accordingly.
- Happy to split these into separate commits/PRs if you prefer one fix per PR.
